### PR TITLE
add file mode permissions for writefile command

### DIFF
--- a/writefile.go
+++ b/writefile.go
@@ -39,7 +39,7 @@ func (r *WriteFileCommand) Execute(variables map[string]any) error {
 
 	// convert string permissions to octal mode by parsing from oct string
 	if r.Permissions != "" {
-		v, err := strconv.ParseInt(r.Permissions, 8, 32)
+		v, err := strconv.ParseUint(r.Permissions, 8, 32)
 		if err == nil {
 			mode = os.FileMode(v)
 		}

--- a/writefile_test.go
+++ b/writefile_test.go
@@ -60,7 +60,7 @@ func TestWriteFile(t *testing.T) {
 		ex.Permissions = "0755"
 		ex.Ectx.Logger = &logger.Logger{}
 
-		m := map[string]any{}
+		m := make(map[string]any)
 		err := ex.Execute(m)
 		c.Assert(err, qt.IsNil)
 
@@ -89,7 +89,7 @@ func TestWriteFile(t *testing.T) {
 		ex.Permissions = "invalid"
 		ex.Ectx.Logger = &logger.Logger{}
 
-		m := map[string]any{}
+		m := make(map[string]any)
 		err := ex.Execute(m)
 		c.Assert(err, qt.IsNil)
 


### PR DESCRIPTION
This pull request adds support for specifying custom file permissions when writing files using the `WriteFileCommand`. It also introduces comprehensive tests to ensure correct handling of permissions, including default, custom, and invalid values.

**WriteFileCommand enhancements:**

* Added a new `Permissions` field to `WriteFileCommand`, allowing users to specify file permissions as an octal string (e.g., `"0755"`). The permissions are parsed and applied when writing the file; if parsing fails, it defaults to `0644`. (`writefile.go`) [[1]](diffhunk://#diff-b4574c98b0ff2655618b4f6b105269358397e9388a9f01f83894b2054c974398L23-R28) [[2]](diffhunk://#diff-b4574c98b0ff2655618b4f6b105269358397e9388a9f01f83894b2054c974398R38-R49)

**Testing improvements:**

* Added tests to verify:
  - Default permissions (`0644`) are applied when no custom value is provided. (`writefile_test.go`)
  - Custom permissions are correctly parsed and set (e.g., `"0755"`). (`writefile_test.go`)
  - Invalid permission strings gracefully fall back to the default (`0644`). (`writefile_test.go`)

**Dependency updates:**

* Imported `os` and `strconv` to support permission parsing and handling. (`writefile.go`, `writefile_test.go`) [[1]](diffhunk://#diff-b4574c98b0ff2655618b4f6b105269358397e9388a9f01f83894b2054c974398R4-R6) [[2]](diffhunk://#diff-848daf4bbbe8ccb26e1d8e53b7157cad904434ef54c77b4088d83fcdd64d537eR6)